### PR TITLE
Fix PHP4-style constructor for the WP_Widget call

### DIFF
--- a/inc/widget-entry-views.php
+++ b/inc/widget-entry-views.php
@@ -46,7 +46,7 @@ class EV_Widget_Entry_Views extends WP_Widget {
 		);
 
 		/* Create the widget. */
-		$this->WP_Widget(
+		parent::__construct(
 			'ev-entry-views',
 			__( 'Entry Views', 'entry-views' ),
 			$widget_options,


### PR DESCRIPTION
As per WordPress 4.3's changes for PHP7 compatibility
