### PR TITLE
Update widget-entry-views.php

### DIFF
--- a/inc/widget-entry-views.php
+++ b/inc/widget-entry-views.php
@@ -46,7 +46,7 @@ class EV_Widget_Entry_Views extends WP_Widget {
 		);
 
 		/* Create the widget. */
-		$this->WP_Widget(
+		parent::__construct(
 			'ev-entry-views',
 			__( 'Entry Views', 'entry-views' ),
 			$widget_options,


### PR DESCRIPTION
fix deprecated notice: `Notice: The called constructor method for WP_Widget is deprecated since version 4.3.0! Use __construct() instead.`
note: https://markjaquith.wordpress.com/2009/09/29/using-php5-object-constructors-in-wp-widget-api/
