### PR TITLE
Use PHP 5 call to parent constructor

### DIFF
--- a/inc/widget-entry-views.php
+++ b/inc/widget-entry-views.php
@@ -46,7 +46,7 @@ class EV_Widget_Entry_Views extends WP_Widget {
 		);
 
 		/* Create the widget. */
-		$this->WP_Widget(
+		parent::__construct(
 			'ev-entry-views',
 			__( 'Entry Views', 'entry-views' ),
 			$widget_options,


### PR DESCRIPTION
The plugin hasn't been updated for years and it generates a warning because of PHP 4 constructor call. This PR simply fixes it.